### PR TITLE
Fix sitemap route handling

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -27,14 +27,6 @@ const nextConfig = {
   experimental: {
     serverActions: true,
   },
-  async rewrites() {
-    return [
-      {
-        source: "/sitemap.xml",
-        destination: "/api/sitemap",
-      },
-    ];
-  },
   async headers() {
     return [
       {


### PR DESCRIPTION
## Summary
- remove rewrite that incorrectly routed `/sitemap.xml` to `/api/sitemap`

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6856bf8b6790832da595abfa55233f77